### PR TITLE
Change main page name

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ const Home = () => {
 	return (
 		<>
 			<Head>
-				<title>Home | Minefly</title>
+				<title>Free, Community First Minecraft Server Hosting | Minefly</title>
 			</Head>
 			<NavBar contained nopadding />
 			<div className="banner w-full relative h-200">


### PR DESCRIPTION
Now, acc to w3schools, they'll display 50-60 chars of the title max. This is under 60, but not 50. we can test it, and here's an under 50 version, although tbh I don't like it: **Free Community First Minecraft Server Host|Minefly**

This is the title that displays in search results as well, so I didn't just want to do "Home | Minefly"